### PR TITLE
fix: attempt to fetch user info when page loads

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,6 +28,7 @@ export class AppComponent {
   }
 
   ngOnInit() {
+    this.userInfoService.fetchUserInfo();
       this.comingSoonTimerID = setTimeout(()=>{
         this.toggleComingSoonPopup();
       }, 2000);


### PR DESCRIPTION
## Problem
We allow the user to login, but the username never appears in the top-right corner

## Approach
* fix: call `fetchUserInfo()` when page first loads

## How to Test
Prerequisites:

* Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) locally, Kubernetes Enabled in the options - this allows you to use `kubectl` CLI
* Install [Helm 3+](https://helm.sh/docs/intro/install/) locally - this allows you to use `helm` CLI

Setup:

1. Checkout this branch locally, change to the `chart` directory: `cd chart/`
2. Change context to your local cluster: `kubectl config use-context docker-desktop`
3. Run with local Helm values and this branch's image: `helm upgrade --install chemscraper-frontend -n mmli --create-namespace . -f values.local.yaml --set controller.image=moleculemaker/chemscraper-frontend:pr-35`

Test Steps:

4. Navigate to http://chemscraper.proxy.localhost and with Log In at the top-right
    * You should be redirected to Keycloak
5. Choose to login with "CILogon"
    * You should be redirected to CILogon
6. From the dropdown menu, choose "University of Illinois Urbana-Champaign" (do not pick NCSA)
    * You should be redirected to university login
7. Enter your university credentials (+ 2FA, if necessary)
    * You should be redirected back to the https://chemscraper.proxy.localhost/configuration (NOTE: due to security, HTTPS is required here to fetch userinfo)
8. You may see a browser certificate warning - if you do, then click the "Advanced" button, and then click the link that says "Proceed"
    * You should see the chemscraper-frontend now loads
    * You should see that your email address now appears at the top-right corner (in place of the "Log In" button)