### PR TITLE
[WIP] feat: added ip-ratelimit middleware

### DIFF
--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -5,6 +5,7 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-ip-ratelimit@kubernetescrd
 
 controller:
   image: moleculemaker/chemscraper-frontend:main

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -5,6 +5,7 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-ip-ratelimit@kubernetescrd
 
 controller:
   image: moleculemaker/chemscraper-frontend:latest


### PR DESCRIPTION
## Problem
We need a generic way to prevent DDoS of CLEAN / MOLLI / ChemScraper and future similar tools

## Approach
* feat: add `ip-ratelimit` Middleware to ingress rules in staging + prod

## How to Test
TBD