### PR TITLE
fix: clipping of page size selector when viewport is tall

### DIFF
--- a/src/app/components/chemscraper/results/results.component.html
+++ b/src/app/components/chemscraper/results/results.component.html
@@ -107,7 +107,7 @@
                   </div>
                 </div>
                 <div class="table-container">
-                  <p-table #resultsTable [value]="filterBySmiles(molecules, marvinJsSmiles)" dataKey="id" selectionMode="single" [(selection)]="selectedMolecule" (onRowSelect)="onRowSelected($event)" (onRowUnselect)="onRowUnselected($event)" [paginator]="true" [rows]="10" [rowsPerPageOptions]="[5, 10, 25]" [scrollable]="true" scrollHeight="700px" styleClass="molecule_table" [(first)]="firstRowIndex">
+                  <p-table #resultsTable [value]="filterBySmiles(molecules, marvinJsSmiles)" dataKey="id" selectionMode="single" paginatorDropdownAppendTo="body" [(selection)]="selectedMolecule" (onRowSelect)="onRowSelected($event)" (onRowUnselect)="onRowUnselected($event)" [paginator]="true" [rows]="10" [rowsPerPageOptions]="[5, 10, 25]" [scrollable]="true" scrollHeight="700px" styleClass="molecule_table" [(first)]="firstRowIndex">
                     <ng-template pTemplate="header">
                       <tr>
                         <!-- <th><p-tableCheckbox></p-tableCheckbox></th> -->


### PR DESCRIPTION
Fixes #85 

originally on results component, the paginator will be clipped if the viewport is tall
<img width="990" alt="image" src="https://github.com/moleculemaker/chemscraper-frontend/assets/20468259/4daeb9db-b7d1-4d28-9699-1930f78a9fbf">
now: 
<img width="1002" alt="image" src="https://github.com/moleculemaker/chemscraper-frontend/assets/20468259/db2f8928-7ed8-4d76-982e-0fa320074871">
