### PR TITLE
fix submission time

### DIFF
--- a/src/app/components/chemscraper/results/results.component.html
+++ b/src/app/components/chemscraper/results/results.component.html
@@ -9,7 +9,7 @@
         <!-- todo: change to output job summary data -->
         <div class="details">
           <div *ngIf="statusResponse" class="sequence_time">Document Submitted: {{statusResponse.job_info}} | Submission
-            Time: {{statusResponse.time_created | date:'short' }}</div>
+            Time: {{(1000 * statusResponse.time_created) | date:'short' }}</div>
         </div>
       </div>
       <div class="spacer"></div>


### PR DESCRIPTION
The `time_created` field returned by the backend has units of seconds, but the `date` pipe assumes units of milliseconds. We'd been seeing the following:

![image](https://github.com/moleculemaker/chemscraper-frontend/assets/5361697/829dc90c-2318-4e20-ac97-ab77c35c0473)

This PR corrects the issue.